### PR TITLE
chore: upgrade React and React-DOM to v19.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "@mdx-js/react": "^3.1.1",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.4.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^3.9.2",
@@ -97,114 +97,146 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.8.0.tgz",
-      "integrity": "sha512-Hb4BkGNnvgCj3F9XzqjiFTpA5IGkjOXwGAOV13qtc27l2qNF8X9rzSp1H5hu8XewlC0DzYtQtZZIOYzRZDyuXg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.3.tgz",
+      "integrity": "sha512-0SpSdnME0RCS6UHSs9XD3ox4bMcCg1JTmjAJ3AU6rcTlX54CZOAEPc2as8uSghX6wfKGT0HWes4TeUpjJMg6FQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
-    "node_modules/@algolia/client-abtesting": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.42.0.tgz",
-      "integrity": "sha512-JLyyG7bb7XOda+w/sp8ch7rEVy6LnWs3qtxr6VJJ2XIINqGsY6U+0L3aJ6QFliBRNUeEAr2QBDxSm8u9Sal5uA==",
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+        "@algolia/autocomplete-shared": "1.19.2"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.19.2"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.3.tgz",
+      "integrity": "sha512-i2C8sBcl3EKXuCd5nlGohW+pZ9pY3P3JKJ2OYqsbCPg6wURiR32hNDiDvDq7/dqJ7KWWwC2snxJhokZzGlckgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.42.0.tgz",
-      "integrity": "sha512-SkCrvtZpdSWjNq9NGu/TtOg4TbzRuUToXlQqV6lLePa2s/WQlEyFw7QYjrz4itprWG9ASuH+StDlq7n49F2sBA==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.3.tgz",
+      "integrity": "sha512-uFmD7m3LOym1SAURHeiqupHT9jui+9HK0lAiIvm077gXEscOM5KKXM4rg/ICzQ3UDHLZEA0Lb5TglWsXnieE6w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.42.0.tgz",
-      "integrity": "sha512-6iiFbm2tRn6B2OqFv9XDTcw5LdWPudiJWIbRk+fsTX+hkPrPm4e1/SbU+lEYBciPoaTShLkDbRge4UePEyCPMQ==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.3.tgz",
+      "integrity": "sha512-SN+yK840nXa+2+mF72hrDfGd8+B7eBjF8TK/8KoRMdjlAkO/P3o3vtpjKRKI/Sk4L8kYYkB/avW8l+cwR+O1Ew==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.42.0.tgz",
-      "integrity": "sha512-iEokmw2k6FBa8g/TT7ClyEriaP/FUEmz3iczRoCklEHWSgoABMkaeYrxRXrA2yx76AN+gyZoC8FX0iCJ55dsOg==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.3.tgz",
+      "integrity": "sha512-5ic1liG0VucNPi6gKCWh5bEUGWQfyEmVeXiNKS+rOSppg7B7nKH0PEEJOFXBbHmgK5aPfNNZINiKcyUoH4XsFA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.42.0.tgz",
-      "integrity": "sha512-ivVniRqX2ARd+jGvRHTxpWeOtO9VT+rK+OmiuRgkSunoTyxk0vjeDO7QkU7+lzBOXiYgakNjkZrBtIpW9c+muw==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.3.tgz",
+      "integrity": "sha512-f4HNitgTip8tntKgluYBTc1LWSOkbNCdxZvRA3rRBZnEAYSvLe7jpE+AxRep6RY+prSWwMtyeCFhA/F1Um+TuQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.42.0.tgz",
-      "integrity": "sha512-9+BIw6rerUfA+eLMIS2lF4mgoeBGTCIHiqb35PLn3699Rm3CaJXz03hChdwAWcA6SwGw0haYXYJa7LF0xI6EpA==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.3.tgz",
+      "integrity": "sha512-/AaVqah2aYyJj7Cazu5QRkgcV3HF3lkBJo5TRkgqQ26xR4iHNRbLF2YsWJfJpJEFghlTF2HOCh7IgzaUCnM+8A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.42.0.tgz",
-      "integrity": "sha512-NZR7yyHj2WzK6D5X8gn+/KOxPdzYEXOqVdSaK/biU8QfYUpUuEA0sCWg/XlO05tPVEcJelF/oLrrNY3UjRbOww==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.3.tgz",
+      "integrity": "sha512-hfpCIukPuwkrlwsYfJEWdU5R5bduBHEq2uuPcqmgPgNq5MSjmiNIzRuzxGZZgiBKcre6gZT00DR7G1AFn//wiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -217,81 +249,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.42.0.tgz",
-      "integrity": "sha512-MBkjRymf4BT6VOvMpJlg6kq8K+PkH9q+N+K4YMNdzTXlL40YwOa1wIWQ5LxP/Jhlz64kW5g9/oaMWY06Sy9dcw==",
+      "version": "1.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.3.tgz",
+      "integrity": "sha512-ChVzNkCzAVxKozTnTgPWCG69WQLjzW7X6OqD91zUh8U38ZhPEX/t3qGhXs+M9ZNaHcJ7xToMB3jywNwONhpLGA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.42.0.tgz",
-      "integrity": "sha512-kmLs7YfjT4cpr4FnhhRmnoSX4psh9KYZ9NAiWt/YcUV33m0B/Os5L4QId30zVXkOqAPAEpV5VbDPWep+/aoJdQ==",
+      "version": "1.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.3.tgz",
+      "integrity": "sha512-MZa+Z5iPmVMxVAQ0aq4HpGsja5utSLEMcOuY01X8D46vvMrSPkP8DnlDFtu1PgJ0RwyIGqqx7v+ClFo6iRJ6bA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.42.0.tgz",
-      "integrity": "sha512-U5yZ8+Jj+A4ZC0IMfElpPcddQ9NCoawD1dKyWmjHP49nzN2Z4284IFVMAJWR6fq/0ddGf4OMjjYO9cnF8L+5tw==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.3.tgz",
+      "integrity": "sha512-cr3atJRJBKgAKZl/Oxo4sig6Se0+ukbyIOOluPV5H+ZAXVcxuMoXQgwQ1M5UHPnCnEsZ4uBXhBmilRgUQpUegw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/client-common": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.42.0.tgz",
-      "integrity": "sha512-EbuxgteaYBlKgc2Fs3JzoPIKAIaevAIwmv1F+fakaEXeibG4pkmVNsyTUjpOZIgJ1kXeqNvDrcjRb6g3vYBJ9A==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.3.tgz",
+      "integrity": "sha512-/Ku9GImJf2SKoRM2S3e03MjCVaWJCP5olih4k54DRhNDdmxBkd3nsWuUXvDElY3Ucw/arBYGs5SYz79SoS5APw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0"
+        "@algolia/client-common": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.42.0.tgz",
-      "integrity": "sha512-4vnFvY5Q8QZL9eDNkywFLsk/eQCRBXCBpE8HWs8iUsFNHYoamiOxAeYMin0W/nszQj6abc+jNxMChHmejO+ftQ==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.3.tgz",
+      "integrity": "sha512-Uw+SPy/zpfwbH1AxQaeOWvWVzPEcO0XbtLbbSz0HPcEIiBGWyfa9LUCxD5UferbDjrSQNVimmzl3FaWi4u8Ykw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0"
+        "@algolia/client-common": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.42.0.tgz",
-      "integrity": "sha512-gkLNpU+b1pCIwk1hKTJz2NWQPT8gsfGhQasnZ5QVv4jd79fKRL/1ikd86P0AzuIQs9tbbhlMwxsSTyJmlq502w==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.3.tgz",
+      "integrity": "sha512-4No9iTjr1GZ0JWsFbQJj9aZBnmKyY1sTxOoEud9+SGe3U6iAulF0A0lI4cWi/F/Gcfg8V3jkaddcqSQKDnE45w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.42.0"
+        "@algolia/client-common": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -3354,6 +3386,48 @@
         }
       }
     },
+    "node_modules/@docsearch/css": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.4.0.tgz",
+      "integrity": "sha512-e9vPgtih6fkawakmYo0Y6V4BKBmDV7Ykudn7ADWXUs5b6pmtBRwDbpSG/WiaUG63G28OkJDEnsMvgIAnZgGwYw==",
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/react": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.4.0.tgz",
+      "integrity": "sha512-z12zeg1mV7WD4Ag4pKSuGukETJLaucVFwszDXL/qLaEgRqxEaVacO9SR1qqnCXvZztlvz2rt7cMqryi/7sKfjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/react": "^2.0.30",
+        "@algolia/autocomplete-core": "1.19.2",
+        "@docsearch/core": "4.4.0",
+        "@docsearch/css": "4.4.0",
+        "ai": "^5.0.30",
+        "algoliasearch": "^5.28.0",
+        "marked": "^16.3.0",
+        "zod": "^4.1.8"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docusaurus/babel": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
@@ -3931,80 +4005,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.2"
-      },
-      "peerDependencies": {
-        "search-insights": ">= 1 < 3"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@algolia/client-search": ">= 4.9.1 < 6",
-        "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docsearch/css": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.4.0.tgz",
-      "integrity": "sha512-e9vPgtih6fkawakmYo0Y6V4BKBmDV7Ykudn7ADWXUs5b6pmtBRwDbpSG/WiaUG63G28OkJDEnsMvgIAnZgGwYw==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docsearch/react": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.4.0.tgz",
-      "integrity": "sha512-z12zeg1mV7WD4Ag4pKSuGukETJLaucVFwszDXL/qLaEgRqxEaVacO9SR1qqnCXvZztlvz2rt7cMqryi/7sKfjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ai-sdk/react": "^2.0.30",
-        "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.4.0",
-        "@docsearch/css": "4.4.0",
-        "ai": "^5.0.30",
-        "algoliasearch": "^5.28.0",
-        "marked": "^16.3.0",
-        "zod": "^4.1.8"
-      },
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 20.0.0",
-        "react": ">= 16.8.0 < 20.0.0",
-        "react-dom": ">= 16.8.0 < 20.0.0",
-        "search-insights": ">= 1 < 3"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "search-insights": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@docusaurus/theme-translations": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
@@ -4261,6 +4261,283 @@
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
       "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.2.tgz",
+      "integrity": "sha512-5s3t0Lj/gDgPhhXEdSe9yNDB07iMrpIXN9OV9FTiwlLKP3EBFhsbOhhMMVoWuSJkPxaaiOFUpZcyZcKi7mOmUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.56.2",
+        "@jsonjoy.com/fs-node-utils": "4.56.2",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.2.tgz",
+      "integrity": "sha512-2lN4rdhcjFBf2Oji0rHR1aS+fW+GA0l9o9gXCMWFoC+YXqRO4N4xkSeJwm6a10SMuqlhoseCWRWlhaDYiNiI2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.56.2",
+        "@jsonjoy.com/fs-node-builtins": "4.56.2",
+        "@jsonjoy.com/fs-node-utils": "4.56.2",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.2.tgz",
+      "integrity": "sha512-Ws4cwm9UQY0noP/Ee2KpPf2zJJukJywjTIl3lBTH/AdH7r5n5CyGPLgySxpAa7/isV0WD02bYV+XKhslF/Dtbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.56.2",
+        "@jsonjoy.com/fs-node-builtins": "4.56.2",
+        "@jsonjoy.com/fs-node-utils": "4.56.2",
+        "@jsonjoy.com/fs-print": "4.56.2",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.2.tgz",
+      "integrity": "sha512-TB8rFES/4lygIudoTHSGp2fjHe7R229VRQ4IQCMds6uTKhBKuDLZAqOUBiS3hosfxTVrB/JpDrr46MvCSjPzog==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.2.tgz",
+      "integrity": "sha512-Es62G93ychdl0VhQKVTIPq31QWabXveTEVJfi3gC/AIiehnXV3AMl38TWXLCS4fomBz5EaLqNhMkV7u/oW1p6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.56.2",
+        "@jsonjoy.com/fs-node-builtins": "4.56.2",
+        "@jsonjoy.com/fs-node-utils": "4.56.2"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.2.tgz",
+      "integrity": "sha512-CIUSlhbnws7b9f3Z2r963/lSA+VLPJlJcy8fqjQ9lk1Z1y6Ca9qj2CWXlABkvDZE7sDX+6PEdEU1PsXlfkZVbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.56.2"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.2.tgz",
+      "integrity": "sha512-7e4hmCrfERuqdNu1shsj140F4uS4h8orBULhlXQJ0F3sT4lnCuWe32rwxAa8xPutb99jKpHcsxM76TaFzFgQTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.56.2",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.2.tgz",
+      "integrity": "sha512-Qh0lc8Ujnb2b1D4RQ7CD+BOzqzw2aUpJPIK9SDv+y9LTy3lZ/ydPU7m6qBIH2ePhBKZuBIyVwxOWSvHRaasETQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.56.2",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+      "version": "17.65.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.65.0.tgz",
+      "integrity": "sha512-Xrh7Fm/M0QAYpekSgmskdZYnFdSGnsxJ/tHaolA4bNwWdG9i65S8m83Meh7FOxyJyQAdo4d4J97NOomBLEfkDQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/buffers": {
+      "version": "17.65.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.65.0.tgz",
+      "integrity": "sha512-eBrIXd0/Ld3p9lpDDlMaMn6IEfWqtHMD+z61u0JrIiPzsV1r7m6xDZFRxJyvIFTEO+SWdYF9EiQbXZGd8BzPfA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.65.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.65.0.tgz",
+      "integrity": "sha512-7MXcRYe7n3BG+fo3jicvjB0+6ypl2Y/bQp79Sp7KeSiiCgLqw4Oled6chVv07/xLVTdo3qa1CD0VCCnPaw+RGA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.65.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.65.0.tgz",
+      "integrity": "sha512-e0SG/6qUCnVhHa0rjDJHgnXnbsacooHVqQHxspjvlYQSkHm+66wkHw6Gql+3u/WxI/b1VsOdUi0M+fOtkgKGdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.65.0",
+        "@jsonjoy.com/buffers": "17.65.0",
+        "@jsonjoy.com/codegen": "17.65.0",
+        "@jsonjoy.com/json-pointer": "17.65.0",
+        "@jsonjoy.com/util": "17.65.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.65.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.65.0.tgz",
+      "integrity": "sha512-uhTe+XhlIZpWOxgPcnO+iSCDgKKBpwkDVTyYiXX9VayGV8HSFVJM67M6pUE71zdnXF1W0Da21AvnhlmdwYPpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.65.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.65.0.tgz",
+      "integrity": "sha512-cWiEHZccQORf96q2y6zU3wDeIVPeidmGqd9cNKJRYoVHTV0S1eHPy5JTbHpMnGfDvtvujQwQozOqgO9ABu6h0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.65.0",
+        "@jsonjoy.com/codegen": "17.65.0"
+      },
       "engines": {
         "node": ">=10.0"
       },
@@ -5770,25 +6047,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.42.0.tgz",
-      "integrity": "sha512-X5+PtWc9EJIPafT/cj8ZG+6IU3cjRRnlHGtqMHK/9gsiupQbAyYlH5y7qt/FtsAhfX5AICHffZy69ZAsVrxWkQ==",
+      "version": "5.46.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.3.tgz",
+      "integrity": "sha512-n/NdPglzmkcNYZfIT3Fo8pnDR/lKiK1kZ1Yaa315UoLyHymADhWw15+bzN5gBxrCA8KyeNu0JJD6mLtTov43lQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.8.0",
-        "@algolia/client-abtesting": "5.42.0",
-        "@algolia/client-analytics": "5.42.0",
-        "@algolia/client-common": "5.42.0",
-        "@algolia/client-insights": "5.42.0",
-        "@algolia/client-personalization": "5.42.0",
-        "@algolia/client-query-suggestions": "5.42.0",
-        "@algolia/client-search": "5.42.0",
-        "@algolia/ingestion": "1.42.0",
-        "@algolia/monitoring": "1.42.0",
-        "@algolia/recommend": "5.42.0",
-        "@algolia/requester-browser-xhr": "5.42.0",
-        "@algolia/requester-fetch": "5.42.0",
-        "@algolia/requester-node-http": "5.42.0"
+        "@algolia/abtesting": "1.12.3",
+        "@algolia/client-abtesting": "5.46.3",
+        "@algolia/client-analytics": "5.46.3",
+        "@algolia/client-common": "5.46.3",
+        "@algolia/client-insights": "5.46.3",
+        "@algolia/client-personalization": "5.46.3",
+        "@algolia/client-query-suggestions": "5.46.3",
+        "@algolia/client-search": "5.46.3",
+        "@algolia/ingestion": "1.46.3",
+        "@algolia/monitoring": "1.46.3",
+        "@algolia/recommend": "5.46.3",
+        "@algolia/requester-browser-xhr": "5.46.3",
+        "@algolia/requester-fetch": "5.46.3",
+        "@algolia/requester-node-http": "5.46.3"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -10857,11 +11134,19 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.52.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.52.0.tgz",
-      "integrity": "sha512-dG5ZY1wUCPWhtl4M2mlc7Wx4OrMGtiI79axnScxwDoPR/25biQYrYm21OpKyZcnKv8pvWaX95SRtZgecZ84gFg==",
+      "version": "4.56.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.2.tgz",
+      "integrity": "sha512-AEbdVTy4TZiugbnfA7d1z9IvwpHlaGh9Vlb/iteHDtUU/WhOKAwgbhy1f8dnX1SMbeKLIXdXf3lVWb55PuBQQw==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@jsonjoy.com/fs-core": "4.56.2",
+        "@jsonjoy.com/fs-fsa": "4.56.2",
+        "@jsonjoy.com/fs-node": "4.56.2",
+        "@jsonjoy.com/fs-node-builtins": "4.56.2",
+        "@jsonjoy.com/fs-node-to-fsa": "4.56.2",
+        "@jsonjoy.com/fs-node-utils": "4.56.2",
+        "@jsonjoy.com/fs-print": "4.56.2",
+        "@jsonjoy.com/fs-snapshot": "^4.56.2",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -10872,6 +11157,9 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/merge-descriptors": {
@@ -14460,28 +14748,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-fast-compare": {
@@ -15248,13 +15532,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/schema-dts": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "@mdx-js/react": "^3.1.1",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.9.2",


### PR DESCRIPTION
Upgraded from React 18.3.1 to 19.2.3 to leverage the latest React features and improvements. Build tested successfully with Docusaurus 3.9.2.