### PR TITLE
docs: update README and CLAUDE.md with current project details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,8 @@ Clear Docusaurus cache and generated files.
 - **Core Dependencies**:
   - @docusaurus/core: ^3.9.2
   - @docusaurus/preset-classic: ^3.9.2
-  - react: ^18.3.1
-  - react-dom: ^18.3.1
+  - react: ^19.2.3
+  - react-dom: ^19.2.3
 - **Styling**: clsx, prism-react-renderer
 - **Markdown**: @mdx-js/react
 - **Dependency Management**: Dependabot configured for weekly npm updates

--- a/README.md
+++ b/README.md
@@ -1,10 +1,54 @@
 # mlwarner.github.io
 
-Github pages using Vitepress.
+Personal blog and portfolio site built with Docusaurus and deployed to GitHub Pages.
 
-## Setup
+## About
 
-Check out and test locally with
+This site showcases technical articles about cloud infrastructure, API development, and software engineering projects.
 
-`npm run docs:dev`
+## Technology Stack
+
+- **Framework**: Docusaurus 3.9 (React-based static site generator)
+- **React**: 19.2.3
+- **Deployment**: GitHub Pages (automatic deployment on push to `main`)
+- **Node Version**: >=18.0
+
+## Development
+
+### Quick Start
+
+Install dependencies:
+```bash
+npm install
+```
+
+Start the development server:
+```bash
+npm start
+```
+
+The site will be available at `http://localhost:3000` with hot reload enabled.
+
+### Available Commands
+
+- `npm start` - Start local development server
+- `npm run build` - Build for production (output to `build/` directory)
+- `npm run serve` - Preview the production build locally
+- `npm run clear` - Clear Docusaurus cache and generated files
+
+## Content Structure
+
+- **Blog posts**: `blog/` directory (format: `YYYY-MM-DD-slug.md`)
+- **Documentation**: `docs/` directory
+- **Custom pages**: `src/pages/` directory
+- **Blog authors**: `blog/authors.yml`
+- **Configuration**: `docusaurus.config.js`
+
+## Deployment
+
+The site automatically deploys to GitHub Pages when changes are pushed to the `main` branch via GitHub Actions (`.github/workflows/deploy.yml`).
+
+## More Information
+
+See [CLAUDE.md](CLAUDE.md) for detailed guidance on working with this codebase.
 


### PR DESCRIPTION
- Update README.md to reflect Docusaurus migration (was referencing VitePress)
- Add comprehensive documentation including tech stack, commands, and content structure
- Update CLAUDE.md to reflect React 19.2.3 upgrade
- Link README to CLAUDE.md for detailed guidance